### PR TITLE
Speed up PDB to Parquet conversion by 3 times.

### DIFF
--- a/src/binder_classification/base/atom_types/atom_types.py
+++ b/src/binder_classification/base/atom_types/atom_types.py
@@ -708,25 +708,17 @@ class Typer:
         if return_occupancy_value:
             pdb_df = PandasPdb().read_pdb(str(inf)).df["ATOM"]
             pdb_df = pdb_df.set_index(["x_coord", "y_coord", "z_coord"])
+            occupancy_lookup = pdb_df["occupancy"].astype(int).to_dict()
             for i in range(len(df)):
-                row = df.iloc[i]
-                                
-                #try:
-                #    occupancy = int(pdb_df.loc[row["x"], row["y"], row["z"]]["occupancy"])
-                #except:
-                #    print('occ error with', inf)
-                #    print(pdb_df.loc[row["x"], row["y"], row["z"]]["occupancy"])
-                #    pass
-                
-                occupancy = int(
-                    pdb_df.loc[row["x"], row["y"], row["z"]]["occupancy"]
-                )
+                x = xs[i]
+                y = ys[i]
+                z = zs[i]
+
+                occupancy = occupancy_lookup[(x, y, z)]
                 occupancy_values.append(occupancy)
         
         return types, occupancy_values
                 
-        
-
     def run(
         self,
         inf: str,

--- a/src/ddg_regression/base/atom_types/atom_types.py
+++ b/src/ddg_regression/base/atom_types/atom_types.py
@@ -708,12 +708,13 @@ class Typer:
         if return_occupancy_value:
             pdb_df = PandasPdb().read_pdb(str(inf)).df["ATOM"]
             pdb_df = pdb_df.set_index(["x_coord", "y_coord", "z_coord"])
+            occupancy_lookup = pdb_df["occupancy"].astype(int).to_dict()
             for i in range(len(df)):
-                row = df.iloc[i]
+                x = xs[i]
+                y = ys[i]
+                z = zs[i]
 
-                occupancy = int(
-                    pdb_df.loc[row["x"], row["y"], row["z"]]["occupancy"]
-                )
+                occupancy = occupancy_lookup[(x, y, z)]
                 occupancy_values.append(occupancy)
         
         return types, occupancy_values


### PR DESCRIPTION
I noticed that converting PDB files to parquet files was notably slow, so I utilized Scalene, a Python profiling tool, to analyze the performance bottlenecks. The profiler's output, problematic part highlighted in the screenshot below, shows significant time consumption in two specific lines of code involving Pandas operations, accounting for 62% of the execution time (blue bars).

![image](https://github.com/amhummer/Graphinity/assets/18399516/3f712133-06b6-4852-8af3-b748535f456f)

In this merge request I have replaced these two lines using a python dictionary which is much faster.
This change made the conversion three times faster and the results are still the same.